### PR TITLE
Fix json syntax error in python-tuf index

### DIFF
--- a/repository/python-tuf/index.json
+++ b/repository/python-tuf/index.json
@@ -1,11 +1,11 @@
 {
   "python-tuf": {
     "1.0.0": "tuf-1.0.0-py3-none-any.whl",
-    "1.1.0": "tuf-1.1.0-py3-none-any.whl",
+    "1.1.0": "tuf-1.1.0-py3-none-any.whl"
   },
   "src": {
     "1.0.0": "tuf-1.0.0.tar.gz",
-    "1.1.0": "tuf-1.1.0.tar.gz",
+    "1.1.0": "tuf-1.1.0.tar.gz"
   }
 }
 


### PR DESCRIPTION
Trailing commas are not allowed in json.

Signed-off-by: Lukas Puehringer <lukas.puehringer@nyu.edu>